### PR TITLE
Specify that the output image should be a PNG.

### DIFF
--- a/lib/frameit/editor.rb
+++ b/lib/frameit/editor.rb
@@ -48,6 +48,7 @@ module Frameit
             end
 
             output_path = screenshot.gsub('.png', '_framed.png').gsub('.PNG', '_framed.png')
+            result.format "png"
             result.write output_path
             Helper.log.info "Added frame: '#{File.expand_path(output_path)}'".green
           end


### PR DESCRIPTION
At the moment the image is being created as a JPEG. On my machine when I try to open the file in photoshop it fails because, given the .png file extension, it assumes it is opening a PNG.

I figure this is a hotfix. Would you prefer in future that I submit a pull request to the develop branch?
