### PR TITLE
Tell MiniMagick to store composite in PNG

### DIFF
--- a/lib/frameit/editor.rb
+++ b/lib/frameit/editor.rb
@@ -46,7 +46,7 @@ module Frameit
               width = offset_information[:width]
               image.resize width
 
-              result = template.composite(image) do |c|
+              result = template.composite(image, "png") do |c|
                 c.compose "Over"
                 c.geometry offset_information[:offset]
               end


### PR DESCRIPTION
Should fix issue 20 and at least some of the problems discussed in issue 8; prevents intermediate translation to JPG and loss of detail/transparency.
