### PR TITLE
Title not horizontally centered when keyword not present

### DIFF
--- a/lib/frameit/editor.rb
+++ b/lib/frameit/editor.rb
@@ -152,7 +152,12 @@ module Frameit
         keyword = title_images[:keyword]
         title = title_images[:title]
 
-        sum_width = (keyword.width rescue 0) + title.width + keyword_padding
+        sum_width = (keyword.width rescue 0) + title.width
+
+        if keyword
+          sum_width += keyword_padding
+        end
+
         top_space = (top_space_above_device / 2.0 - actual_font_size / 2.0).round # centered
         
         left_space = (image.width / 2.0 - sum_width / 2.0).round
@@ -161,9 +166,10 @@ module Frameit
             c.compose "Over"
             c.geometry "+#{left_space}+#{top_space}"
           end
-        end
 
-        left_space += (keyword.width rescue 0) + keyword_padding
+          left_space += (keyword.width rescue 0) + keyword_padding
+        end
+        
         @image = image.composite(title, "png") do |c|
           c.compose "Over"
           c.geometry "+#{left_space}+#{top_space}"


### PR DESCRIPTION
This fixes an issue where the title would not be horizontally centered if there was no keyword.

Before:
![before](https://cloud.githubusercontent.com/assets/98044/8800892/8ba4bb6a-2f84-11e5-8502-55eaf2a897a5.png)

After:
![after](https://cloud.githubusercontent.com/assets/98044/8800909/8f5acb00-2f84-11e5-92df-3b4ee528a70a.png)
