### PR TITLE
Update offsets.rb to fix offset error on iPad

### DIFF
--- a/lib/frameit/offsets.rb
+++ b/lib/frameit/offsets.rb
@@ -29,8 +29,8 @@ module Frameit
               }
             when size::IOS_IPAD
               return {
-                'offset' => '+50+134',
-                'width' => 792
+                'offset' => '+47+127',
+                'width' => 744
               }
           end
         when Orientation::LANDSCAPE


### PR DESCRIPTION
Modified vertical iPad width and offset to fix framing issue with Apple's current marketing material.
