### PR TITLE
Add ability to control the 'overhang' of the device image.

### DIFF
--- a/lib/frameit/config_parser.rb
+++ b/lib/frameit/config_parser.rb
@@ -89,11 +89,11 @@ module Frameit
           end
 
           if key == 'landscape_overhang_multiplier'
-            raise "landscape_overhang_multiplier must be a float" unless value.is_a? Numeric
+            raise "landscape_overhang_multiplier must be a float" unless value.kind_of? Numeric
           end
 
           if key == 'portrait_overhang_multiplier'
-            raise "portrait_overhang_multiplier must be a float" unless value.is_a? Numeric
+            raise "portrait_overhang_multiplier must be a float" unless value.kind_of? Numeric
           end
 
         end

--- a/lib/frameit/config_parser.rb
+++ b/lib/frameit/config_parser.rb
@@ -87,6 +87,15 @@ module Frameit
           if key == 'padding'
             raise "padding must be type integer" unless value.kind_of? Integer
           end
+
+          if key == 'landscape_overhang_multiplier'
+            raise "landscape_overhang_multiplier must be a float" unless value.is_a? Numeric
+          end
+
+          if key == 'portrait_overhang_multiplier'
+            raise "portrait_overhang_multiplier must be a float" unless value.is_a? Numeric
+          end
+
         end
       end
     end

--- a/lib/frameit/editor.rb
+++ b/lib/frameit/editor.rb
@@ -122,6 +122,12 @@ module Frameit
       background
     end
 
+    def overhang_multiplier
+      key = screenshot.portrait? ? 'portrait_overhang_multiplier' : 'landscape_overhang_multiplier'
+    
+      return fetch_config[key] || 1.0;
+    end
+
     def put_device_into_background(background)
       left_space = (background.width / 2.0 - image.width / 2.0).round
       bottom_space = -(image.height / 10).round # to be just a bit below the image bottom
@@ -132,6 +138,8 @@ module Frameit
         bottom_space -= 50 if screenshot.portrait?
         bottom_space += 65 unless screenshot.portrait?
       end
+      
+      bottom_space *= overhang_multiplier
 
       self.top_space_above_device = background.height - image.height - bottom_space
 

--- a/lib/frameit/editor.rb
+++ b/lib/frameit/editor.rb
@@ -125,7 +125,7 @@ module Frameit
     def overhang_multiplier
       key = screenshot.portrait? ? 'portrait_overhang_multiplier' : 'landscape_overhang_multiplier'
     
-      return fetch_config[key] || 1.0;
+      return fetch_config[key] || 1.0
     end
 
     def put_device_into_background(background)
@@ -138,7 +138,7 @@ module Frameit
         bottom_space -= 50 if screenshot.portrait?
         bottom_space += 65 unless screenshot.portrait?
       end
-      
+
       bottom_space *= overhang_multiplier
 
       self.top_space_above_device = background.height - image.height - bottom_space


### PR DESCRIPTION
Adding default values in the framefile such as:
    "landscape_overhang_multiplier": 0,
    "portrait_overhang_multiplier": 0.7
causes landscape screenshots to show the entire device, and portrait
screenshots to show a little more then before.
(the default 1.0 causes no change)
