### PR TITLE
Support for multi-line titles

### DIFF
--- a/lib/frameit/config_parser.rb
+++ b/lib/frameit/config_parser.rb
@@ -85,7 +85,7 @@ module Frameit
           end
 
           if key == 'padding'
-            raise "padding must be type integer" unless value.kind_of? Integer
+            raise "padding must be type integer or pair of integers of format 'AxB'" unless value.kind_of?(Integer) || value.split('x').length == 2
           end
         end
       end

--- a/lib/frameit/editor.rb
+++ b/lib/frameit/editor.rb
@@ -92,7 +92,7 @@ module Frameit
         @image = put_into_frame
 
         # Decrease the size of the framed screenshot to fit into the defined padding + background
-        frame_width = background.width - frame_padding * 2
+        frame_width = background.width - horizontal_frame_padding * 2
         image.resize "#{frame_width}x"
       end
 
@@ -105,7 +105,7 @@ module Frameit
         bottom_space += 65 unless screenshot.portrait?
       end
 
-      self.top_space_above_device = frame_padding
+      self.top_space_above_device = vertical_frame_padding
 
       if fetch_config['title']
         background = put_title_into_background(background)
@@ -116,11 +116,28 @@ module Frameit
       image
     end
 
-    # Padding around the frames
-    def frame_padding
+    # Horizontal adding around the frames
+    def horizontal_frame_padding
+      padding = fetch_config['padding']
+      if !padding.kind_of?(Integer)
+        padding = padding.split('x')[0].to_i
+      end
+      return scale_padding(padding)
+    end
+
+    # Vertical adding around the frames
+    def vertical_frame_padding
+      padding = fetch_config['padding']
+      if !padding.kind_of?(Integer)
+        padding = padding.split('x')[1].to_i
+      end
+      return scale_padding(padding)
+    end
+
+    def scale_padding padding
       multi = 1.0
       multi = 1.7 if self.screenshot.triple_density?
-      return fetch_config['padding'] * multi
+      return padding * multi
     end
 
     # Returns a correctly sized background image
@@ -179,7 +196,7 @@ module Frameit
         sum_width *= smaller
       end
 
-      vertical_padding = frame_padding
+      vertical_padding = vertical_frame_padding
       top_space = vertical_padding
       left_space = (background.width / 2.0 - sum_width / 2.0).round
 

--- a/lib/frameit/editor.rb
+++ b/lib/frameit/editor.rb
@@ -96,15 +96,6 @@ module Frameit
         image.resize "#{frame_width}x"
       end
 
-      bottom_space = -(image.height / 10).round # to be just a bit below the image bottom
-      bottom_space -= 40 if screenshot.portrait? # even more for portrait mode
-
-      if screenshot.mini?
-        # Such small devices need special treatment
-        bottom_space -= 50 if screenshot.portrait?
-        bottom_space += 65 unless screenshot.portrait?
-      end
-
       self.top_space_above_device = vertical_frame_padding
 
       if fetch_config['title']
@@ -119,7 +110,7 @@ module Frameit
     # Horizontal adding around the frames
     def horizontal_frame_padding
       padding = fetch_config['padding']
-      if !padding.kind_of?(Integer)
+      unless padding.kind_of?(Integer)
         padding = padding.split('x')[0].to_i
       end
       return scale_padding(padding)
@@ -128,13 +119,13 @@ module Frameit
     # Vertical adding around the frames
     def vertical_frame_padding
       padding = fetch_config['padding']
-      if !padding.kind_of?(Integer)
+      unless padding.kind_of?(Integer)
         padding = padding.split('x')[1].to_i
       end
       return scale_padding(padding)
     end
 
-    def scale_padding padding
+    def scale_padding(padding)
       multi = 1.0
       multi = 1.7 if self.screenshot.triple_density?
       return padding * multi
@@ -170,7 +161,6 @@ module Frameit
     end
 
     # Add the title above the device
-    # rubocop:disable Metrics/AbcSize
     def put_title_into_background(background)
       title_images = build_title_images(image.width, image.height)
 
@@ -219,7 +209,6 @@ module Frameit
       end
       background
     end
-    # rubocop:enable Metrics/AbcSize
 
     def actual_font_size
       [@image.width / 10.0].max.round
@@ -294,7 +283,7 @@ module Frameit
       result = fetch_config[type.to_s]['text'] if fetch_config[type.to_s]
       Helper.log.debug "Falling back to default text as there was nothing specified in the .strings file" if $verbose
 
-      if !result and type == :title
+      if type == :title and !result
         # title is mandatory
         raise "Could not get title for screenshot #{screenshot.path}. Please provide one in your Framefile.json".red
       end

--- a/lib/frameit/screenshot.rb
+++ b/lib/frameit/screenshot.rb
@@ -22,9 +22,9 @@ module Frameit
       sizes = Deliver::AppScreenshot::ScreenSize
       case @screen_size
       when sizes::IOS_55
-        return 'iPhone_6_Plus'
+        return 'iPhone-6s-Plus'
       when sizes::IOS_47
-        return 'iPhone_6'
+        return 'iPhone-6s'
       when sizes::IOS_40
         return 'iPhone_5s'
       when sizes::IOS_35

--- a/lib/frameit/template_finder.rb
+++ b/lib/frameit/template_finder.rb
@@ -11,7 +11,7 @@ module Frameit
       ]
       joiner = "_"
 
-      if screenshot.device_name.include?('iPad')
+      if screenshot.device_name.include?('iPad') || screenshot.device_name.include?('6s')
         parts = [
           screenshot.device_name,
           (screenshot.color == 'SpaceGray' ? "Space-Gray" : "Silver"),


### PR DESCRIPTION
This is WIP-ish, looking for feedback :)

Enhancements:
- Multi-line titles! Just add `\n` to your strings (8e747d5741c)
- Support for horizontal and vertical padding (`"padding": "100x20"` in Framefile.json)
- Support for latest Apple device frame filenames (6s series)

Issues that I can think of:
- Keywords kind of break (suggested interim solution: limit keyword support to only one-line titles)
- It won't be pixel-for-pixel perfect compared to the previous implementation, but it's preeeeetty close

Multi-line files look like...
One line:
![iphone_6s_plus-portrait-oneline_framed](https://cloud.githubusercontent.com/assets/33126/11193626/fc5327cc-8ca7-11e5-8763-7caeec0e5b97.png)

Two lines:
![iphone_6s_plus-portrait-twolines_framed](https://cloud.githubusercontent.com/assets/33126/11193627/fc78e48a-8ca7-11e5-84cf-6c363646ae96.png)

Four lines:
![iphone_6s_plus-portrait-fourlines_framed](https://cloud.githubusercontent.com/assets/33126/11193630/029e38c4-8ca8-11e5-91e2-ab3ab20eb417.png)

Works for all devices that I have frames for:
![screen shot 2015-11-16 at 9 22 29 pm](https://cloud.githubusercontent.com/assets/33126/11193656/30c4ae0e-8ca8-11e5-891a-f41d1c5cb284.png)
