### PR TITLE
Providing option to specify custom font size

### DIFF
--- a/lib/frameit/editor.rb
+++ b/lib/frameit/editor.rb
@@ -173,8 +173,8 @@ module Frameit
       sum_width += keyword.width + keyword_padding if keyword
 
       # Only resize if we haven't specified a custom font size
-      font_size = fontSize('title')
-      if font_size == nil
+      font_size = font_size('title')
+      if font_size.nil?
         # Resize the 2 labels if necessary
         smaller = 1.0 # default
         ratio = (sum_width + keyword_padding * 2) / image.width.to_f
@@ -238,7 +238,7 @@ module Frameit
         end
 
         current_font = font(key)
-        custom_font_size = fontSize(key)
+        custom_font_size = font_size(key)
         text = fetch_text(key)
         UI.message "Using #{current_font} as font the #{key} of #{screenshot.path}" if $verbose and current_font
         UI.message "Adding text '#{text}'" if $verbose
@@ -327,14 +327,13 @@ module Frameit
       return nil
     end
     
-    
-    def scaledFontSize(fontSize)
-      fontRatio = fontSize / 640.0
-      return (fontRatio * screenshot.size[0].to_f).round
+    def scaled_font_size(font_size)
+      font_ratio = font_size / 640.0
+      return (font_ratio * screenshot.size[0].to_f).round
     end
 
     # The fontSize we want to use
-    def fontSize(key)
+    def font_size(key)
       single_font_size = fetch_config[key.to_s]['fontSize']
       return single_font_size if single_font_size
 
@@ -344,19 +343,19 @@ module Frameit
           if font['supported']
             font['supported'].each do |language|
               if screenshot.path.include? language
-                return scaledFontSize(font["fontSize"])
+                return scaled_font_size(font["fontSize"])
               end
             end
           else
             # No `supported` array, this will always be true
             UI.message "Found a fontSize with no list of supported languages, using this now" if $verbose
-            return scaledFontSize(font["fontSize"])
+            return scaled_font_size(font["fontSize"])
           end
         end
       end
 
       UI.message "No custom fontSize specified for #{screenshot}, using the default one" if $verbose
       return nil
-    end    
+    end
   end
 end

--- a/lib/frameit/editor.rb
+++ b/lib/frameit/editor.rb
@@ -326,7 +326,7 @@ module Frameit
       UI.message "No custom font specified for #{screenshot}, using the default one" if $verbose
       return nil
     end
-    
+
     def scaled_font_size(font_size)
       font_ratio = font_size / 640.0
       return (font_ratio * screenshot.size[0].to_f).round

--- a/lib/frameit/editor.rb
+++ b/lib/frameit/editor.rb
@@ -172,18 +172,22 @@ module Frameit
       sum_width = title.width
       sum_width += keyword.width + keyword_padding if keyword
 
-      # Resize the 2 labels if necessary
-      smaller = 1.0 # default
-      ratio = (sum_width + keyword_padding * 2) / image.width.to_f
-      if ratio > 1.0
-        # too large - resizing now
-        smaller = (1.0 / ratio)
+      # Only resize if we haven't specified a custom font size
+      font_size = fontSize('title')
+      if font_size == nil
+        # Resize the 2 labels if necessary
+        smaller = 1.0 # default
+        ratio = (sum_width + keyword_padding * 2) / image.width.to_f
+        if ratio > 1.0
+          # too large - resizing now
+          smaller = (1.0 / ratio)
 
-        UI.message "Text for image #{self.screenshot.path} is quite long, reducing font size by #{(ratio - 1.0).round(2)}" if $verbose
+          Helper.log.debug "Text for image #{self.screenshot.path} is quite long, reducing font size by #{(ratio - 1.0).round(2)}" if $verbose
 
-        title.resize "#{(smaller * title.width).round}x"
-        keyword.resize "#{(smaller * keyword.width).round}x" if keyword
-        sum_width *= smaller
+          title.resize "#{(smaller * title.width).round}x"
+          keyword.resize "#{(smaller * keyword.width).round}x" if keyword
+          sum_width *= smaller
+        end
       end
 
       vertical_padding = vertical_frame_padding
@@ -210,13 +214,13 @@ module Frameit
       background
     end
 
-    def actual_font_size
+    def derived_font_size
       [@image.width / 10.0].max.round
     end
 
     # The space between the keyword and the title
     def keyword_padding
-      (actual_font_size / 2.0).round
+      (derived_font_size / 2.0).round
     end
 
     # This will build 2 individual images with the title, which will then be added to the real image
@@ -234,6 +238,7 @@ module Frameit
         end
 
         current_font = font(key)
+        custom_font_size = fontSize(key)
         text = fetch_text(key)
         UI.message "Using #{current_font} as font the #{key} of #{screenshot.path}" if $verbose and current_font
         UI.message "Adding text '#{text}'" if $verbose
@@ -244,7 +249,12 @@ module Frameit
         title_image.combine_options do |i|
           i.font current_font if current_font
           i.gravity "Center"
-          i.pointsize actual_font_size
+          if custom_font_size
+            i.pointsize custom_font_size
+            UI.message "Using custom font size #{custom_font_size}" if $verbose
+          else
+            i.pointsize derived_font_size
+          end
           i.draw "text 0,0 '#{text}'"
           i.fill fetch_config[key.to_s]['color']
         end
@@ -316,5 +326,37 @@ module Frameit
       UI.message "No custom font specified for #{screenshot}, using the default one" if $verbose
       return nil
     end
+    
+    
+    def scaledFontSize(fontSize)
+      fontRatio = fontSize / 640.0
+      return (fontRatio * screenshot.size[0].to_f).round
+    end
+
+    # The fontSize we want to use
+    def fontSize(key)
+      single_font_size = fetch_config[key.to_s]['fontSize']
+      return single_font_size if single_font_size
+
+      fonts = fetch_config[key.to_s]['fonts']
+      if fonts
+        fonts.each do |font|
+          if font['supported']
+            font['supported'].each do |language|
+              if screenshot.path.include? language
+                return scaledFontSize(font["fontSize"])
+              end
+            end
+          else
+            # No `supported` array, this will always be true
+            UI.message "Found a fontSize with no list of supported languages, using this now" if $verbose
+            return scaledFontSize(font["fontSize"])
+          end
+        end
+      end
+
+      UI.message "No custom fontSize specified for #{screenshot}, using the default one" if $verbose
+      return nil
+    end    
   end
 end

--- a/lib/frameit/editor.rb
+++ b/lib/frameit/editor.rb
@@ -182,7 +182,7 @@ module Frameit
           # too large - resizing now
           smaller = (1.0 / ratio)
 
-          Helper.log.debug "Text for image #{self.screenshot.path} is quite long, reducing font size by #{(ratio - 1.0).round(2)}" if $verbose
+          UI.message "Text for image #{self.screenshot.path} is quite long, reducing font size by #{(ratio - 1.0).round(2)}" if $verbose
 
           title.resize "#{(smaller * title.width).round}x"
           keyword.resize "#{(smaller * keyword.width).round}x" if keyword


### PR DESCRIPTION
I recently set up `frameit` for our project and I'm liking it a lot. One thing I'm missing though is the option to specify a custom font size that would be used instead of letting frameit calculate the desired font size to fit a string. This is especially more desirable since recently the option to specify multi-line titles has been added.

For instance, in this set of screenshots we're generating for our app, the middle one gets shrunken down quite a bit, see image below:

![derived_font](https://cloud.githubusercontent.com/assets/1628978/13055566/4b1c9dd4-d410-11e5-87d3-488aeb94c319.png)

In the App Store, having those 5 screenshots side by side would defintely make the middle one stand out in an odd way, especially since it'll also render the device in a slightly different position due to the smaller font size.

This PR adds the option of specifying a custom font size in the Framefile, like this:

```
"title": {
      "fonts": [
        {
          "font": "./fonts/MrEavesSanNoBounceOT-Book.otf",
          "fontSize": 48,
          "supported": ["da_DK", "en_US", "es_ES", "fr_FR", "it_IT", "de_DE", "pt_PT"]
        },
        {
          "font": "./fonts/ArialUnicode.ttf",
          "fontSize": 28,
          "supported": ["zh-Hans", "zh-Hant", "ja_JP", "ru_RU"]
        }
      ],
      "color": "#ffffff"
    },
```

It will result in the screenshots being rendered using the same font size in every screenshot. I realize that this could lead to cropped titles, but that's why we have the multiline option to fully customize the layout of the title, right?

Below is an image of `frameit` run off this branch, will the titles all in the same font size. Happy to hear your thoughts!

![custom_font](https://cloud.githubusercontent.com/assets/1628978/13055668/e9e1a644-d410-11e5-80dc-195957242e71.png)
 