### PR TITLE
Add option to specify custom font size for each screen resolution

### DIFF
--- a/lib/frameit/editor.rb
+++ b/lib/frameit/editor.rb
@@ -338,13 +338,13 @@ module Frameit
       fonts = fetch_config[key.to_s]['fonts']
       if fonts
         fonts.each do |font|
-          next if font['supported'].nil?
+          next unless font['supported']
           font['supported'].each do |language|
-              next if !screenshot.path.include? language || !font['fontSize']
-              font_size = font['fontSize'][font_key]
-              return font_size if font_size
-            end
+            next unless (screenshot.path.include? language && font['fontSize'])
+             font_size = font['fontSize'][font_key]
+            return font_size if font_size
           end
+        end
       end
 
       UI.message "No custom fontSize specified for #{screenshot}, using the default one" if $verbose

--- a/lib/frameit/editor.rb
+++ b/lib/frameit/editor.rb
@@ -330,7 +330,6 @@ module Frameit
     # The fontSize we want to use
     def font_size(key)
       font_key = "#{screenshot.size[0]}x#{screenshot.size[1]}"
-      
       if fetch_config[key.to_s]['fontSize']
         single_font_size = fetch_config[key.to_s]['fontSize'][font_key]
         return single_font_size if single_font_size
@@ -339,17 +338,13 @@ module Frameit
       fonts = fetch_config[key.to_s]['fonts']
       if fonts
         fonts.each do |font|
-          if font['supported']
-            font['supported'].each do |language|
-              if screenshot.path.include? language
-                if font['fontSize']
-                  font_size = font['fontSize'][font_key]
-                  return font_size if font_size
-                end
-              end
+          next if font['supported'].nil?
+          font['supported'].each do |language|
+              next if !screenshot.path.include? language || !font['fontSize']
+              font_size = font['fontSize'][font_key]
+              return font_size if font_size
             end
           end
-        end
       end
 
       UI.message "No custom fontSize specified for #{screenshot}, using the default one" if $verbose

--- a/lib/frameit/editor.rb
+++ b/lib/frameit/editor.rb
@@ -340,8 +340,8 @@ module Frameit
         fonts.each do |font|
           next unless font['supported']
           font['supported'].each do |language|
-            next unless (screenshot.path.include? language && font['fontSize'])
-             font_size = font['fontSize'][font_key]
+            next unless (screenshot.path.include? language) && font['fontSize']
+            font_size = font['fontSize'][font_key]
             return font_size if font_size
           end
         end


### PR DESCRIPTION
Okay, this should hopefully be a bit more bulletproof now!
#107 introduced the option to specify a custom font size, but it didn't really take into account  various device resolutions and orientations. This PR builds on that, but it now requires you to specify the device resolution along with the desired font size in your `Framefile.json`, like so:

```
"title": {
      "font": "./fonts/MrEavesSanNoBounceOT-Book.otf",
      "fontSize": {
            "1536x2048" : 48,
            "2048x1536" : 32,
            "2048x2732" : 60,
            "2732x2048" : 30,
            "1242x2208" : 48,
            "2208x1242" : 32,
            "750x1334" : 30,
            "1334x750" : 20,
            "640x1136" : 27,
            "1136x640" : 18
      },
      "color": "#000000"
    },
```

Thought about using something like `iPhone6_landscape` etc. as the keys instead of the resolutions, but it seemed a little prone to error due to misspelling.

Hope this clears out any unexpected results. @dvalenzuela-com could you test this with your project and let me know if it now generates the screenshots as expected now, and if it fixed the error?
